### PR TITLE
Build a binary using Golang on Github Actions

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -28,13 +28,15 @@ jobs:
         run: ls -lsh .
       - name: Build binary for the required OS and architecture
         run: |
-          GOOS=${{ matrix.os-flavor }} GOARCH=${{ matrix.architecture }} go build -o $(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }} ${{ matrix.path-to-build }}
+          GOOS=${{ matrix.os-flavor }} GOARCH=${{ matrix.architecture }} go build -ldflags="-X \"github.com/icyflame/kindle-my-clippings-parser/internal/env.Version=${{ github.ref }} $GITHUB_SHA\"" -o $(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }} ${{ matrix.path-to-build }}
+
       - name: Print the branch/tag name and the commit hash
         run: |
-          echo "Ref: ${{ github.ref }}; Commit: ${{ github.after }}"
+          echo "Ref: ${{ github.ref }}; Commit: $GITHUB_SHA"
       - name: Print file output of the binary file that was built
         run: |
           file ./$(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }}
+          ./$(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }} -version
           sha256sum ./$(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }}
       - name: Upload binaries if a tag was pushed
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -1,0 +1,20 @@
+name: Build Binary
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.22.5' ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+      # You can test your matrix by printing the current Go version
+      - name: Display Go version
+        run: go version

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -24,23 +24,27 @@ jobs:
         run: go version
       - name: Get dependencies
         run: go get ./...
-      - name: Print the list of files
-        run: ls -lsh .
-      - name: Build binary for the required OS and architecture
-        run: |
-          GOOS=${{ matrix.os-flavor }} GOARCH=${{ matrix.architecture }} go build -ldflags="-X \"github.com/icyflame/kindle-my-clippings-parser/internal/env.Version=${{ github.ref }} $GITHUB_SHA\"" -o $(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }} ${{ matrix.path-to-build }}
-
-      - name: Print the branch/tag name and the commit hash
+      - name: Build binary for the given paths
         run: |
           echo "Ref: ${{ github.ref }}; Commit: $GITHUB_SHA"
-      - name: Print file output of the binary file that was built
-        run: |
+
+          OUTPUT_FILE_NAME="./$(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }}"
+
+          GOOS=${{ matrix.os-flavor }} GOARCH=${{ matrix.architecture }} \
+            go build \
+            -ldflags="-X \"github.com/icyflame/kindle-my-clippings-parser/internal/env.Version=${{ github.ref }} $GITHUB_SHA\"" \
+            -o $OUTPUT_FILE_NAME ${{ matrix.path-to-build }}
+
+          sha256sum $OUTPUT_FILE_NAME > $OUTPUT_FILE_NAME.checksum
+
           file ./$(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }}
-          ./$(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }} -version
-          sha256sum ./$(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }}
+          file ./$(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }}.checksum
+
+          ls -lsh .
       - name: Upload binaries if a tag was pushed
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
             ./$(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }}
+            ./$(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }}.checksum

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -8,9 +8,13 @@ jobs:
     strategy:
       matrix:
         go-version: [ '1.22.5' ]
+        os-flavor: [ 'linux' ]
+        architecture: [ 'amd64', 'arm', 'arm64' ]
+        path-to-build: [ './cmd/email-random' ]
 
     steps:
       - uses: actions/checkout@v4
+      # Caching is enabled by default when using setup-go
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
         with:
@@ -18,3 +22,10 @@ jobs:
       # You can test your matrix by printing the current Go version
       - name: Display Go version
         run: go version
+      - name: Get dependencies
+        run: go get ./...
+      - name: Print the list of files
+        run: ls -lsh .
+      - name: Print command used to build binaries
+        run: |
+          echo GOOS=${{ matrix.os-flavor }} GOARCH=${{ matrix.architecture }} go build -o $(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }} ${{ matrix.path-to-build }}

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -26,6 +26,19 @@ jobs:
         run: go get ./...
       - name: Print the list of files
         run: ls -lsh .
-      - name: Print command used to build binaries
+      - name: Build binary for the required OS and architecture
         run: |
-          echo GOOS=${{ matrix.os-flavor }} GOARCH=${{ matrix.architecture }} go build -o $(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }} ${{ matrix.path-to-build }}
+          GOOS=${{ matrix.os-flavor }} GOARCH=${{ matrix.architecture }} go build -o $(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }} ${{ matrix.path-to-build }}
+      - name: Print the branch/tag name and the commit hash
+        run: |
+          echo "Ref: ${{ github.ref }}; Commit: ${{ github.after }}"
+      - name: Print file output of the binary file that was built
+        run: |
+          file ./$(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }}
+          sha256sum ./$(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }}
+      - name: Upload binaries if a tag was pushed
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ./$(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }}

--- a/cmd/email-random/main.go
+++ b/cmd/email-random/main.go
@@ -34,9 +34,16 @@ func main() {
 func _main() error {
 	var inputFilePath string
 	var verbose bool
+	var version bool
+	flag.BoolVar(&version, "version", false, "Print the build version")
 	flag.StringVar(&inputFilePath, "input-file-path", "", "Input file. Input file should be the YAML file that is output by the cmd/parse command in this project.")
 	flag.BoolVar(&verbose, "verbose", false, "Enable verbose logging")
 	flag.Parse()
+
+	if version {
+		fmt.Println(env.Version)
+		return nil
+	}
 
 	if inputFilePath == "" {
 		return errors.New("input file path must be non-empty")

--- a/internal/env/config.go
+++ b/internal/env/config.go
@@ -7,6 +7,8 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
+var Version string = "unset"
+
 type Environment struct {
 	SendgridAPIKey string `envconfig:"SENDGRID_API_KEY" required:"true"`
 	SenderName     string `envconfig:"sender_name"`


### PR DESCRIPTION
While setting up a new ARM64 server which will run the `email-random` binary periodically, I realized that my current approach was to install Golang on the server => download the code for this application => build the application locally => run that binary.

This is unnecessary. It would be better to build a single binary for multiple architectures and upload it as a release artifact for each pushed tag on GitHub. This PR builds for various architectures and OSes on GitHub Actions and uploads them.

I have not tested the tag upload feature yet. It can be tested only after this PR has been merged into the default branch.